### PR TITLE
楽曲種別取得 API を定義

### DIFF
--- a/generated/oas/openapi.yaml
+++ b/generated/oas/openapi.yaml
@@ -19,8 +19,36 @@ paths:
                 $ref: '#/components/schemas/ListSongTypeResponse'
       tags:
         - SongType
+  /song-types/{songTypeId}:
+    get:
+      operationId: getSongType
+      description: 楽曲種別取得API
+      parameters:
+        - name: songTypeId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/uuid'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSongTypeResponse'
+        '404':
+          description: The server cannot find the requested resource.
+      tags:
+        - SongType
 components:
   schemas:
+    GetSongTypeResponse:
+      type: object
+      required:
+        - songType
+      properties:
+        songType:
+          $ref: '#/components/schemas/SongType'
     ListSongTypeResponse:
       type: object
       required:

--- a/src/song-types.tsp
+++ b/src/song-types.tsp
@@ -35,3 +35,18 @@ op listSongTypes(): {
   @statusCode statusCode: 200;
   @body response: ListSongTypeResponse;
 };
+
+model GetSongTypeResponse {
+  songType: SongType;
+}
+
+@doc("楽曲種別取得API")
+@tag("SongType")
+@route("/song-types")
+@get
+op getSongType(@path songTypeId: uuid): {
+  @statusCode statusCode: 200;
+  @body response: GetSongTypeResponse;
+} | {
+  @statusCode statusCode: 404;
+};


### PR DESCRIPTION
## 概要

楽曲種別取得 API を定義した
<!-- この PR の概要を記載する -->

## やったこと

- 楽曲種別取得 API を定義

<!-- この PR でやったことを箇条書きで記載する -->

## やってないこと

- エラーハンドリング
<!-- この PR でやってないことを箇条書きで記載する -->

## 関連

<!-- 関連する ISSUE や PR へのリンクがあれば記載する -->
